### PR TITLE
fix: migrate CLI to Yargs, fix --config boolean coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-02-14 (CLI Migration)
+
+### Changed
+- Migrated CLI (`src/cli/cli.ts`) from hand-rolled argument parser to Yargs with subcommands
+- `--config key=value` now properly coerces booleans (`false` → `false`), `null`, numbers, and JSON objects/arrays — previously only coerced numbers, leaving `"false"` as a truthy string
+- All commands and subcommands now support `--help` with auto-generated usage, options, and defaults
+
+### Removed
+- Manual boolean coercion workaround in `src/bot/agents/atrx.ts` (no longer needed with proper CLI coercion)
+
+### Added
+- `yargs` dependency for CLI argument parsing
+
+---
+
 ## 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,34 @@ All types are derived from Zod schemas via `z.infer<>`. Schemas live in `src/sch
 
 ## CLI
 
-All commands go through `bun run src/cli/cli.ts <command>`.
+All commands go through `bun run src/cli/cli.ts <command>`. Every command and subcommand supports `--help` for usage info.
+
+```bash
+# See all commands
+bun run src/cli/cli.ts --help
+
+# See subcommands for a group
+bun run src/cli/cli.ts agents --help
+
+# See options for a specific command
+bun run src/cli/cli.ts agents run --help
+```
+
+### Config Overrides
+
+The `--config` flag accepts `key=value` pairs with automatic type coercion:
+
+| Value | Coerced To |
+|---|---|
+| `true` / `false` | boolean |
+| `null` | null |
+| `42`, `0.5` | number |
+| `{"a":1}`, `[1,2]` | parsed JSON |
+| anything else | string |
+
+```bash
+bun run src/cli/cli.ts backtest macd --dataset x --config debug=false threshold=0.5 tradeAmount=10
+```
 
 ### Live Trading
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,17 @@
     "": {
       "name": "iqoption",
       "dependencies": {
+        "drizzle-orm": "^0.45.1",
+        "hono": "^4.11.9",
+        "onnxruntime-node": "^1.18.0",
+        "yargs": "^18.0.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/yargs": "^17.0.35",
+        "better-sqlite3": "^12.6.2",
+        "drizzle-kit": "^0.31.9",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -16,16 +23,296 @@
     },
   },
   "packages": {
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
+    "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
+
+    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.9", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "hono": ["hono@4.11.9", "", {}, "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.24.1", "", {}, "sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.1", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-Ex/oUXKdhDoxvlNxBT3oYtW0MH88yYpPlXQeVQUXpcJQmN24usd/8RCoPLN5kCHwDsiZ+nqsnjciyFRl423dQw=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/yargs": "^17.0.35",
     "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.9"
   },
@@ -26,6 +27,7 @@
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",
     "onnxruntime-node": "^1.18.0",
+    "yargs": "^18.0.0",
     "zod": "^4.3.6"
   }
 }

--- a/src/bot/agents/atrx.ts
+++ b/src/bot/agents/atrx.ts
@@ -1,0 +1,596 @@
+import type { Candle, Position } from "../../types/index.ts";
+import type {
+  Agent,
+  Action,
+  Observation,
+  TradingEnvironmentInterface,
+} from "../../env/types.ts";
+import type { AgentContext } from "../../env/agent-context.ts";
+
+import { SensorManager } from "../../env/sensors.ts";
+
+export interface ATRXAgentConfig {
+  activeId: number;
+  agentId?: string;
+
+  // Timeframes (seconds)
+  trendCandleSize: number; // e.g. 300 (5m)
+  entryCandleSize: number; // e.g. 60  (1m)
+
+  // Execution
+  tradeAmount: number;
+  baseExpirationSize: number; // e.g. 60
+  fastExpirationSize: number; // e.g. 30
+  allowFastExpiry: boolean;
+  maxOpenTrades: number;
+  warmupCandles: number;
+
+  // Market gates
+  minPayoutPercent: number;
+  deadtimeSeconds: number;
+
+  // Trend/regime (trend timeframe)
+  emaTrendPeriod: number;
+  emaTrendSlopeLookback: number;
+  minTrendSlopePct: number; // abs(emaSlope) / price * 100
+
+  atrPeriod: number;
+  atrWindow: number;
+  atrPctMin: number; // ATR/price * 100
+  atrPctMax: number; // ATR/price * 100
+  atrPercentileMin: number;
+  atrPercentileMax: number;
+
+  // Entry mechanics (entry timeframe)
+  emaEntryPeriod: number;
+  swingLookback: number;
+  breakoutBufferPct: number;
+  setupTtlCandles: number;
+
+  retestProximityAtr: number;
+  retestMinBodyPct: number;
+  levelEmaProximityAtr: number;
+  maxExtensionAtr: number;
+  impulseAtrK: number;
+
+  // Fast expiry qualification
+  fastMinTrendSlopePct: number;
+  fastMaxAtrPct: number;
+
+  // Risk
+  cooldownAfterTrade: number;
+  maxConsecutiveLosses: number;
+  lossPauseDuration: number;
+  maxTotalLoss: number; // stop trading when totalPnl <= -maxTotalLoss
+
+  debug: boolean;
+}
+
+export const DEFAULT_ATRX_CONFIG: Omit<ATRXAgentConfig, "activeId"> = {
+  agentId: "dyn",
+
+  trendCandleSize: 300,
+  entryCandleSize: 60,
+
+  tradeAmount: 20,
+  baseExpirationSize: 60,
+  fastExpirationSize: 30,
+  allowFastExpiry: true,
+  maxOpenTrades: 1,
+  // Sensor buffers keep the last ~100 candles; keep warmup <= that.
+  warmupCandles: 100,
+
+  minPayoutPercent: 80,
+  deadtimeSeconds: 8,
+
+  emaTrendPeriod: 50,
+  emaTrendSlopeLookback: 3,
+  minTrendSlopePct: 0.002,
+
+  atrPeriod: 14,
+  atrWindow: 100,
+  atrPctMin: 0.005,
+  atrPctMax: 0.25,
+  atrPercentileMin: 20,
+  atrPercentileMax: 85,
+
+  emaEntryPeriod: 20,
+  swingLookback: 12,
+  breakoutBufferPct: 0.01,
+  setupTtlCandles: 6,
+
+  retestProximityAtr: 0.35,
+  retestMinBodyPct: 45,
+  levelEmaProximityAtr: 0.9,
+  maxExtensionAtr: 1.4,
+  impulseAtrK: 0.45,
+
+  fastMinTrendSlopePct: 0.004,
+  fastMaxAtrPct: 0.06,
+
+  cooldownAfterTrade: 30,
+  maxConsecutiveLosses: 3,
+  lossPauseDuration: 180,
+  maxTotalLoss: 200,
+
+  debug: false,
+};
+
+type Direction = "call" | "put";
+
+type PendingSetup = {
+  direction: Direction;
+  level: number;
+  createdAt: number;
+  expiresAt: number;
+  origin: "breakout";
+};
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function ema(values: number[], period: number): number[] {
+  if (values.length === 0) return [];
+  const p = Math.max(1, Math.floor(period));
+  const k = 2 / (p + 1);
+  const out: number[] = [values[0]!];
+  for (let i = 1; i < values.length; i++) {
+    out.push(values[i]! * k + out[i - 1]! * (1 - k));
+  }
+  return out;
+}
+
+function trueRange(curr: Candle, prevClose: number | undefined): number {
+  const high = curr.max;
+  const low = curr.min;
+  if (prevClose === undefined) return high - low;
+  return Math.max(high - low, Math.abs(high - prevClose), Math.abs(low - prevClose));
+}
+
+// Wilder/RMA smoothing, common for ATR
+function atr(candles: Candle[], period: number): number[] {
+  const p = Math.max(1, Math.floor(period));
+  if (candles.length === 0) return [];
+  const tr: number[] = [];
+  for (let i = 0; i < candles.length; i++) {
+    const prevClose = i > 0 ? candles[i - 1]!.close : undefined;
+    tr.push(trueRange(candles[i]!, prevClose));
+  }
+  const out: number[] = [];
+  let prev = tr[0]!;
+  out.push(prev);
+  for (let i = 1; i < tr.length; i++) {
+    prev = (prev * (p - 1) + tr[i]!) / p;
+    out.push(prev);
+  }
+  return out;
+}
+
+function highestHigh(candles: Candle[], lookback: number): number {
+  const lb = Math.max(1, Math.floor(lookback));
+  const start = Math.max(0, candles.length - lb);
+  let hi = -Infinity;
+  for (let i = start; i < candles.length; i++) {
+    hi = Math.max(hi, candles[i]!.max);
+  }
+  return hi;
+}
+
+function lowestLow(candles: Candle[], lookback: number): number {
+  const lb = Math.max(1, Math.floor(lookback));
+  const start = Math.max(0, candles.length - lb);
+  let lo = Infinity;
+  for (let i = start; i < candles.length; i++) {
+    lo = Math.min(lo, candles[i]!.min);
+  }
+  return lo;
+}
+
+function candleBodyPct(c: Candle): number {
+  const range = Math.max(1e-12, c.max - c.min);
+  const body = Math.abs(c.close - c.open);
+  return (body / range) * 100;
+}
+
+function percentileRank(values: number[], value: number): number {
+  if (values.length === 0) return 0;
+  let below = 0;
+  for (const v of values) {
+    if (v < value) below++;
+  }
+  return (below / values.length) * 100;
+}
+
+function safeNow(obs: Observation): number {
+  return obs.timestamp || Math.floor(Date.now() / 1000); // lint:allow-date-now — fallback only
+}
+
+function remainingInWindow(now: number, windowSec: number): number {
+  const w = Math.max(1, Math.floor(windowSec));
+  return w - (now % w);
+}
+
+export class ATRXAgent implements Agent {
+  name = "ATRX";
+
+  private cfg: ATRXAgentConfig;
+  private ctx: AgentContext | undefined;
+
+  private balanceId = 0;
+  private profitPercent = 80;
+
+  private lastEntryFrom = 0;
+  private pending: PendingSetup | null = null;
+  private cooldownUntil = 0;
+  private consecutiveLosses = 0;
+  private pauseUntil = 0;
+  private stopTrading = false;
+
+  constructor(config: ATRXAgentConfig) {
+    this.cfg = config;
+    const suffix = config.agentId || "dyn";
+    this.name = `ATRX-${suffix}`;
+  }
+
+  private dbg(msg: string, data?: unknown): void {
+    if (!this.cfg.debug) return;
+    console.log(`[${this.name}:DBG] ${msg}`);
+    if (this.ctx) this.ctx.log.debug(msg, data);
+  }
+
+  async initialize(env: TradingEnvironmentInterface, ctx?: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.balanceId = env.getBalanceId();
+
+    const obs = env.getObservation();
+    const asset = obs.state.availableAssets.find(a => a.active_id === this.cfg.activeId);
+    if (asset && asset.profit_commission > 0) {
+      this.profitPercent = 100 - asset.profit_commission;
+    }
+
+    const trendId = SensorManager.candleId(this.cfg.activeId, this.cfg.trendCandleSize);
+    const entryId = SensorManager.candleId(this.cfg.activeId, this.cfg.entryCandleSize);
+
+    await env.executeActions([
+      {
+        type: "subscribe",
+        payload: {
+          id: trendId,
+          type: "candle",
+          params: { active_id: this.cfg.activeId, size: this.cfg.trendCandleSize },
+        },
+      },
+      {
+        type: "subscribe",
+        payload: {
+          id: entryId,
+          type: "candle",
+          params: { active_id: this.cfg.activeId, size: this.cfg.entryCandleSize },
+        },
+      },
+    ]);
+
+    // Prefill to enable gates immediately.
+    try {
+      const candlesApi = env.getCandlesAPI();
+      const count = Math.max(this.cfg.warmupCandles, this.cfg.atrWindow + this.cfg.atrPeriod + 20);
+      const trendHist = await candlesApi.getFirstCandles(this.cfg.activeId, this.cfg.trendCandleSize, count);
+      const entryHist = await candlesApi.getFirstCandles(this.cfg.activeId, this.cfg.entryCandleSize, count);
+      if (trendHist.length > 0) env.prefillSensor(trendId, trendHist);
+      if (entryHist.length > 0) env.prefillSensor(entryId, entryHist);
+      this.dbg("Prefilled candles", { trend: trendHist.length, entry: entryHist.length });
+    } catch (err) {
+      console.warn(`[${this.name}] Failed to prefill candles:`, (err as Error).message);
+    }
+
+    console.log(
+      `[${this.name}] active=${this.cfg.activeId} | trend=${this.cfg.trendCandleSize}s | entry=${this.cfg.entryCandleSize}s | ` +
+      `exp=${this.cfg.baseExpirationSize}s` +
+      (this.cfg.allowFastExpiry ? `/${this.cfg.fastExpirationSize}s` : "") +
+      ` | $${this.cfg.tradeAmount} | minPayout=${this.cfg.minPayoutPercent}%` +
+      (this.cfg.debug ? " | DEBUG ON" : "")
+    );
+  }
+
+  async onObservation(obs: Observation): Promise<Action[]> {
+    const now = safeNow(obs);
+    if (this.stopTrading) return [];
+
+    if (this.cfg.maxTotalLoss > 0 && obs.state.totalPnl <= -Math.abs(this.cfg.maxTotalLoss)) {
+      this.stopTrading = true;
+      console.log(`[${this.name}] STOP: maxTotalLoss reached (totalPnl=${obs.state.totalPnl.toFixed(2)})`);
+      if (this.ctx) this.ctx.events.emit("agent:debug", { message: "maxTotalLoss reached", totalPnl: obs.state.totalPnl });
+      return [];
+    }
+
+    if (now < this.pauseUntil) {
+      this.dbg(`Paused for ${this.pauseUntil - now}s`);
+      return [];
+    }
+    if (now < this.cooldownUntil) {
+      this.dbg(`Cooldown for ${this.cooldownUntil - now}s`);
+      return [];
+    }
+    if (obs.state.openPositions.length >= this.cfg.maxOpenTrades) {
+      this.dbg(`Max open trades reached: ${obs.state.openPositions.length}/${this.cfg.maxOpenTrades}`);
+      return [];
+    }
+    if (this.profitPercent < this.cfg.minPayoutPercent) {
+      this.dbg(`Payout gate: profitPercent=${this.profitPercent} < min=${this.cfg.minPayoutPercent}`);
+      return [];
+    }
+
+    const trendId = SensorManager.candleId(this.cfg.activeId, this.cfg.trendCandleSize);
+    const entryId = SensorManager.candleId(this.cfg.activeId, this.cfg.entryCandleSize);
+    const trendAll = obs.sensors.get(trendId) as Candle[] | undefined;
+    const entryAll = obs.sensors.get(entryId) as Candle[] | undefined;
+    if (!trendAll || !entryAll) return [];
+    if (trendAll.length < 10 || entryAll.length < 10) return [];
+
+    // Only act once per *new* entry candle open.
+    const latestEntry = entryAll[entryAll.length - 1]!;
+    if (latestEntry.from === this.lastEntryFrom) return [];
+    this.lastEntryFrom = latestEntry.from;
+
+    const trendCandles = trendAll.slice(0, -1);
+    const entryCandles = entryAll.slice(0, -1);
+    // Buffers are capped (live+backtest default ~100), so use derived minimums.
+    const minTrend = Math.max(
+      this.cfg.emaTrendPeriod + this.cfg.emaTrendSlopeLookback + 2,
+      this.cfg.atrPeriod + 2,
+    );
+    const minEntry = Math.max(
+      this.cfg.emaEntryPeriod + 2,
+      this.cfg.atrPeriod + 2,
+      this.cfg.swingLookback + 3,
+    );
+    if (trendCandles.length < minTrend) return [];
+    if (entryCandles.length < minEntry) return [];
+
+    const last = entryCandles[entryCandles.length - 1]!;
+
+    // Deadtime gate
+    const remainingBase = remainingInWindow(now, this.cfg.baseExpirationSize);
+    if (remainingBase < this.cfg.deadtimeSeconds) {
+      this.dbg(`Deadtime: ${remainingBase}s remaining (base window)`);
+      return [];
+    }
+
+    // Trend direction + strength (trend timeframe)
+    const trendCloses = trendCandles.map(c => c.close);
+    const trendEma = ema(trendCloses, this.cfg.emaTrendPeriod);
+    if (trendEma.length < this.cfg.emaTrendSlopeLookback + 2) return [];
+    const emaNow = trendEma[trendEma.length - 1]!;
+    const emaPrev = trendEma[trendEma.length - 1 - this.cfg.emaTrendSlopeLookback]!;
+    const trendPrice = trendCloses[trendCloses.length - 1]!;
+    const trendSlopePct = ((emaNow - emaPrev) / Math.max(1e-12, trendPrice)) * 100;
+    const slopeAbs = Math.abs(trendSlopePct);
+    if (slopeAbs < this.cfg.minTrendSlopePct) {
+      this.dbg(`Trend gate: slopeAbs=${slopeAbs.toFixed(6)}% < min=${this.cfg.minTrendSlopePct}%`);
+      this.pending = null;
+      return [];
+    }
+
+    let trendDir: Direction | null = null;
+    if (trendSlopePct > 0 && trendPrice >= emaNow) trendDir = "call";
+    if (trendSlopePct < 0 && trendPrice <= emaNow) trendDir = "put";
+    if (!trendDir) {
+      this.dbg("Trend gate: price/EMA misaligned", { trendSlopePct, trendPrice, emaNow });
+      this.pending = null;
+      return [];
+    }
+
+    // Regime (ATR percentile + ATR%) on trend timeframe
+    const trendAtrSeries = atr(trendCandles, this.cfg.atrPeriod);
+    const trendAtrNow = trendAtrSeries[trendAtrSeries.length - 1] || 0;
+    const atrPct = trendPrice > 0 ? (trendAtrNow / trendPrice) * 100 : 0;
+    if (atrPct < this.cfg.atrPctMin || atrPct > this.cfg.atrPctMax) {
+      this.dbg(`ATR% gate: ${atrPct.toFixed(4)}% outside [${this.cfg.atrPctMin}, ${this.cfg.atrPctMax}]`);
+      this.pending = null;
+      return [];
+    }
+
+    const wStart = Math.max(0, trendAtrSeries.length - this.cfg.atrWindow);
+    const atrWindow = trendAtrSeries.slice(wStart);
+    const atrRank = percentileRank(atrWindow, trendAtrNow);
+    if (atrRank < this.cfg.atrPercentileMin || atrRank > this.cfg.atrPercentileMax) {
+      this.dbg(`ATR rank gate: ${atrRank.toFixed(1)} outside [${this.cfg.atrPercentileMin}, ${this.cfg.atrPercentileMax}]`, {
+        atrRank,
+        trendAtrNow,
+        atrPct,
+      });
+      this.pending = null;
+      return [];
+    }
+
+    // Entry timeframe ATR + EMA
+    const entryCloses = entryCandles.map(c => c.close);
+    const entryEma = ema(entryCloses, this.cfg.emaEntryPeriod);
+    const entryEmaNow = entryEma[entryEma.length - 1] || last.close;
+    const entryAtrSeries = atr(entryCandles, this.cfg.atrPeriod);
+    const entryAtrNow = entryAtrSeries[entryAtrSeries.length - 1] || 0;
+
+    // Drop pending if trend flipped or stale
+    if (this.pending && now >= this.pending.expiresAt) {
+      this.dbg("Setup expired");
+      this.pending = null;
+    }
+    if (this.pending && this.pending.direction !== trendDir) {
+      this.dbg("Trend flipped; dropping setup");
+      this.pending = null;
+    }
+
+    // No-chase gate (avoid trading when too extended from entry EMA)
+    if (entryAtrNow > 0) {
+      const extAtr = Math.abs(last.close - entryEmaNow) / entryAtrNow;
+      if (extAtr > this.cfg.maxExtensionAtr) {
+        this.dbg(`Extension gate: ext=${extAtr.toFixed(2)}ATR > max=${this.cfg.maxExtensionAtr}`);
+        return [];
+      }
+    }
+
+    // Build or consume setup (breakout -> retest+rejection)
+    if (!this.pending) {
+      const recent = entryCandles.slice(0, -1);
+      if (recent.length < this.cfg.swingLookback + 2) return [];
+
+      if (trendDir === "call") {
+        const level = highestHigh(recent, this.cfg.swingLookback);
+        const buffer = (this.cfg.breakoutBufferPct / 100) * level;
+        // Breakout: wick makes a higher high and close confirms above the level.
+        if (last.max > level + buffer && last.close > level && last.close > last.open) {
+          const ttlSec = this.cfg.setupTtlCandles * this.cfg.entryCandleSize;
+          this.pending = {
+            direction: "call",
+            level,
+            createdAt: now,
+            expiresAt: now + ttlSec,
+            origin: "breakout",
+          };
+          this.dbg("Setup created CALL", { level, ttlSec, lastClose: last.close, lastHigh: last.max });
+        }
+      } else {
+        const level = lowestLow(recent, this.cfg.swingLookback);
+        const buffer = (this.cfg.breakoutBufferPct / 100) * level;
+        // Breakout: wick makes a lower low and close confirms below the level.
+        if (last.min < level - buffer && last.close < level && last.close < last.open) {
+          const ttlSec = this.cfg.setupTtlCandles * this.cfg.entryCandleSize;
+          this.pending = {
+            direction: "put",
+            level,
+            createdAt: now,
+            expiresAt: now + ttlSec,
+            origin: "breakout",
+          };
+          this.dbg("Setup created PUT", { level, ttlSec, lastClose: last.close, lastLow: last.min });
+        }
+      }
+      return [];
+    }
+
+    // Retest + rejection
+    const level = this.pending.level;
+    const prox = entryAtrNow > 0 ? this.cfg.retestProximityAtr * entryAtrNow : 0;
+    const nearLevel = this.pending.direction === "call"
+      ? (last.min <= level + prox)
+      : (last.max >= level - prox);
+    if (!nearLevel) {
+      this.dbg("Waiting retest", { dir: this.pending.direction, level, close: last.close });
+      return [];
+    }
+
+    // Level should be near the entry EMA (acts like dynamic support/resistance)
+    if (entryAtrNow > 0) {
+      const levelEmaDist = Math.abs(level - entryEmaNow) / entryAtrNow;
+      if (levelEmaDist > this.cfg.levelEmaProximityAtr) {
+        this.dbg(`Level/EMA mismatch: dist=${levelEmaDist.toFixed(2)}ATR > max=${this.cfg.levelEmaProximityAtr}`);
+        return [];
+      }
+    }
+
+    const bodyPct = candleBodyPct(last);
+    if (bodyPct < this.cfg.retestMinBodyPct) {
+      this.dbg(`Weak rejection: bodyPct=${bodyPct.toFixed(1)} < min=${this.cfg.retestMinBodyPct}`);
+      return [];
+    }
+
+    const direction = this.pending.direction;
+    let rejection = false;
+    if (direction === "call") {
+      rejection = last.min <= level + prox && last.close > level && last.close > last.open;
+    } else {
+      rejection = last.max >= level - prox && last.close < level && last.close < last.open;
+    }
+    if (!rejection) {
+      this.dbg("No rejection yet", { direction, level, candle: { open: last.open, close: last.close, min: last.min, max: last.max } });
+      return [];
+    }
+
+    // Determine expiry
+    let expirationSize = this.cfg.baseExpirationSize;
+    const impulse = entryAtrNow > 0
+      ? (Math.abs(last.close - last.open) >= this.cfg.impulseAtrK * entryAtrNow)
+      : false;
+    const strongTrend = Math.abs(trendSlopePct) >= this.cfg.fastMinTrendSlopePct;
+    const lowAtr = atrPct <= this.cfg.fastMaxAtrPct;
+    if (this.cfg.allowFastExpiry && impulse && strongTrend && lowAtr) {
+      const remainingFast = remainingInWindow(now, this.cfg.fastExpirationSize);
+      if (remainingFast >= this.cfg.deadtimeSeconds) {
+        expirationSize = this.cfg.fastExpirationSize;
+      }
+    }
+
+    const remaining = remainingInWindow(now, expirationSize);
+    if (remaining < this.cfg.deadtimeSeconds) {
+      this.dbg(`Deadtime: ${remaining}s remaining (chosen window)`);
+      return [];
+    }
+
+    const confidence = clamp(
+      0.55 +
+        Math.min(0.25, slopeAbs / Math.max(1e-12, this.cfg.fastMinTrendSlopePct) * 0.1) +
+        (impulse ? 0.1 : 0),
+      0,
+      0.95,
+    );
+
+    if (this.ctx) {
+      this.ctx.log.signal(direction, confidence, [
+        `trendSlopePct=${trendSlopePct.toFixed(4)}%`,
+        `atrRank=${atrRank.toFixed(1)}`,
+        `atrPct=${atrPct.toFixed(4)}%`,
+        `break+retest level=${level.toFixed(6)}`,
+        impulse ? `impulse>=${this.cfg.impulseAtrK}ATR` : "noImpulse",
+      ]);
+    }
+
+    console.log(
+      `[${this.name}] ${direction.toUpperCase()} $${this.cfg.tradeAmount} | ` +
+      `exp=${expirationSize}s (${remaining}s left) | level=${level.toFixed(6)} close=${last.close.toFixed(6)} | ` +
+      `slope=${trendSlopePct.toFixed(4)}% atrRank=${atrRank.toFixed(1)} atr%=${atrPct.toFixed(4)}%`
+    );
+
+    this.pending = null;
+    this.cooldownUntil = now + this.cfg.cooldownAfterTrade;
+
+    return [
+      {
+        type: "trade",
+        payload: {
+          activeId: this.cfg.activeId,
+          direction,
+          price: this.cfg.tradeAmount,
+          balanceId: this.balanceId,
+          expirationSize,
+          profitPercent: clamp(this.profitPercent, 0, 100),
+          currentPrice: last.close,
+        } as Record<string, unknown>,
+      },
+    ];
+  }
+
+  onTradeResult(position: Position): void {
+    const isWin = position.close_reason === "win";
+    if (isWin) {
+      this.consecutiveLosses = 0;
+      return;
+    }
+
+    this.consecutiveLosses++;
+    if (this.consecutiveLosses >= this.cfg.maxConsecutiveLosses) {
+      this.pauseUntil = (this.ctx?.now() ?? Math.floor(Date.now() / 1000)) + this.cfg.lossPauseDuration; // lint:allow-date-now — fallback only
+      console.log(`[${this.name}] PAUSED after ${this.consecutiveLosses} losses | resume in ${this.cfg.lossPauseDuration}s`);
+      if (this.ctx) this.ctx.events.emit("agent:debug", { message: "paused on loss streak", losses: this.consecutiveLosses });
+    }
+  }
+}
+
+export function createAgent(config: Record<string, unknown>): Agent {
+  const merged: ATRXAgentConfig = {
+    ...DEFAULT_ATRX_CONFIG,
+    ...config,
+  } as ATRXAgentConfig;
+
+  return new ATRXAgent(merged);
+}


### PR DESCRIPTION
## Summary

- Rewrote `src/cli/cli.ts` from ~1020 lines of hand-rolled argument parsing to **Yargs** with typed subcommands
- `--config key=value` now properly coerces: `"false"` → `false`, `"true"` → `true`, `"null"` → `null`, numbers, and JSON objects/arrays (previously only coerced numbers, leaving `"false"` as a truthy string)
- Removed manual boolean coercion workaround in `src/bot/agents/atrx.ts`
- All commands/subcommands now support `--help` with auto-generated usage info
- Updated CHANGELOG.md and README.md CLI docs

## Test plan

- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test` — 22 pass, 0 fail
- [ ] `bun run src/cli/cli.ts --help` — shows all commands
- [ ] `bun run src/cli/cli.ts agents --help` — shows subcommands
- [ ] `bun run src/cli/cli.ts backtest myagent --dataset x --config debug=false threshold=0.5` — verify `false` → boolean, `0.5` → number

Closes #3