### PR TITLE
Auto-generate dataset names + CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-02-14 (Auto-generated dataset names & CSV export)
+
+### Changed
+- `dataset create` no longer accepts `--name`. Names are auto-generated from parameters as `{activeId}_{size}s_{YYYYMMDD}_{YYYYMMDD}` (e.g. `76_5s_20260210_20260213`). Same params always produce the same name, preventing duplicate fetches.
+
+### Added
+- `iq dataset export <name>` command — exports dataset candles to CSV (`timestamp,open,high,low,close,volume`). Defaults to `./<name>.csv`, override with `--output <path>`.
+
+---
+
 ## 2026-02-14 (CLI: Assets, Auth SSID & `iq` command)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ bun run src/cli/cli.ts agents run momentum --active 76 --config tradeAmount=50
 bun run src/cli/cli.ts agents list
 
 # Backtest an agent offline (no IQ connection needed)
-bun run src/cli/cli.ts dataset create --name eurusd-5s --active 76 --candle-size 5 --from 2026-02-10 --to 2026-02-13
-bun run src/cli/cli.ts backtest macd --dataset eurusd-5s --balance 100
+bun run src/cli/cli.ts dataset create --active 76 --candle-size 5 --from 2026-02-10 --to 2026-02-13
+bun run src/cli/cli.ts backtest macd --dataset 76_5s_20260210_20260213 --balance 100
 ```
 
 ## Architecture
@@ -102,13 +102,18 @@ Datasets store historical candle data in SQLite for offline backtesting. Creatin
 
 ```bash
 # Create a dataset (fetches candles from IQ Option)
-bun run src/cli/cli.ts dataset create --name eurusd-5s --active 76 --candle-size 5 --from 2026-02-10 --to 2026-02-13
+# Name is auto-generated: 76_5s_20260210_20260213
+bun run src/cli/cli.ts dataset create --active 76 --candle-size 5 --from 2026-02-10 --to 2026-02-13
 
 # List datasets
 bun run src/cli/cli.ts dataset list
 
+# Export dataset to CSV
+bun run src/cli/cli.ts dataset export 76_5s_20260210_20260213
+bun run src/cli/cli.ts dataset export 76_5s_20260210_20260213 --output ~/data/eurusd.csv
+
 # Delete a dataset
-bun run src/cli/cli.ts dataset delete eurusd-5s
+bun run src/cli/cli.ts dataset delete 76_5s_20260210_20260213
 ```
 
 ### Backtesting


### PR DESCRIPTION
## Summary
- **Auto-generated dataset names**: `dataset create` no longer accepts `--name`. Names are deterministically generated as `{activeId}_{size}s_{YYYYMMDD}_{YYYYMMDD}` (e.g. `76_5s_20260210_20260213`), preventing duplicate fetches of the same data under different names.
- **CSV export**: New `dataset export <name> [--output <path>]` command writes candle data as CSV (`timestamp,open,high,low,close,volume`) for external analysis. Defaults to `./<name>.csv`.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors in `cli.ts`
- [x] `bun test` — all 22 tests pass
- [x] `dataset create --help` — `--name` removed, shows only `--active`, `--candle-size`, `--from`, `--to`
- [x] `dataset export --help` — shows positional `name` and `--output` option
- [x] `dataset export test-eurusd-60s` — writes 1436 candles to `./test-eurusd-60s.csv`
- [x] `dataset export test-eurusd-60s --output /tmp/custom.csv` — custom path works
- [x] `dataset export nonexistent` — prints "not found" error
- [x] CSV header is `timestamp,open,high,low,close,volume`, row count matches candle count