### PR TITLE
Fix get-candles API params (from_id/to_id → from/to)

### DIFF
--- a/src/api/candles.ts
+++ b/src/api/candles.ts
@@ -63,14 +63,14 @@ export class CandlesAPI {
   async getCandles(
     activeId: number,
     size: number,
-    fromId: number,
-    toId: number,
+    from: number,
+    to: number,
   ): Promise<Candle[]> {
     const res = await this.protocol.sendMessage("get-candles", "2.0", {
       active_id: activeId,
       size,
-      from_id: fromId,
-      to_id: toId,
+      from,
+      to,
     });
     const parsed = CandlesResponseSchema.safeParse(res.msg);
     if (parsed.success) return parsed.data.candles;


### PR DESCRIPTION
## Summary
- `getCandles()` in `src/api/candles.ts` was sending `from_id`/`to_id` but the IQ Option WebSocket API expects `from`/`to`. The wrong param names caused the API to silently return empty candle arrays, breaking `dataset create` for all assets.

## Test plan
- [x] `bun test` — all 22 tests pass
- [x] `iq dataset create --active 1938` (APPLE-OTC) — 4317 candles fetched
- [x] `iq dataset create --active 2111` (AUDUSD-OTC) — 4309 candles fetched
- [x] `iq dataset create --active 2270` (BTCUSD-OTC) — 4309 candles fetched